### PR TITLE
Avoid read speaker reads selected text

### DIFF
--- a/linguatec_lexicon_frontend/static/js/base.js
+++ b/linguatec_lexicon_frontend/static/js/base.js
@@ -48,3 +48,18 @@ $(function () {
         }
     });
 });
+
+
+function specialReadText(url, player_id) {
+  // clear selected text to avoid be read by speaker
+  var sel = window.getSelection ? window.getSelection() : document.selection;
+  if (sel) {
+      if (sel.removeAllRanges) {
+          sel.removeAllRanges();
+      } else if (sel.empty) {
+          sel.empty();
+      }
+  }
+  // ugly hack because timing affects player behaviour
+  setTimeout(() => { readpage(url, player_id); }, 200);
+}

--- a/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/speaker-player.html
+++ b/linguatec_lexicon_frontend/templates/linguatec_lexicon_frontend/components/speaker-player.html
@@ -2,7 +2,7 @@
 
 <div id="speaker_player_{{ wordid }}" class="rs_skip rsbtn rs_preserve d-none">
     <a rel="nofollow" class="rsbtn_play" accesskey="L"
-       title="Escucha esta p&aacute;gina utilizando ReadSpeaker webReader"
+       title="ReadSpeaker webReader"
        href="//app-eu.readspeaker.com/cgi-bin/rsent?customerid=11263&amp;lang=es_es&amp;readid=word_{{ wordid }}&amp;url={{ request.build_absolute_uri|urlencode }}">
         <span class="rsbtn_left rsimg rspart">
             <span class="rsbtn_text">
@@ -14,7 +14,7 @@
 </div>
 <sup class="rs_skip rs_preserve rs_href">
     <a href="//app-eu.readspeaker.com/cgi-bin/rsent?customerid=11263&amp;lang=es_es&amp;readid=word_{{ wordid }}&amp;url={{ request.build_absolute_uri|urlencode }}"
-       onclick="readpage(this.href, 'speaker_player_{{ wordid }}'); return false;">
-        <img src="{% static 'speaker.svg' %}" alt="Listen with ReadSpeaker" width="16">
+       onclick="specialReadText(this.href, 'speaker_player_{{ wordid }}'); return false;">
+        <img src="{% static 'speaker.svg' %}" alt="Escuchar" width="16">
     </a>
 </sup>


### PR DESCRIPTION
Each player should read marked words.

## How to test
1. Go to a word definition (e.g. perform a search)
2. Select any text on the web
3. Click on any speaker icon
4. Previously selected text is read (instead of the marked text)

## Changes done
Wrap readpage method to clear selected text (if any).